### PR TITLE
Fix selection filter import for SplitLayers tool

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/SplitLayers.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/SplitLayers.pushbutton/script.py
@@ -19,6 +19,21 @@ from pyrevit.forms import TemplateListItem
 
 from Autodesk.Revit import DB
 
+try:
+    from Autodesk.Revit.UI.Selection import ISelectionFilter as _RevitSelectionFilterBase
+except ImportError:
+    from Autodesk.Revit.UI import Selection as _RevitSelectionModule
+
+    _RevitSelectionFilterBase = getattr(_RevitSelectionModule, "ISelectionFilter", None)
+
+if _RevitSelectionFilterBase is None:
+    _RevitSelectionFilterBase = getattr(DB, "ISelectionFilter", None)
+
+if _RevitSelectionFilterBase is None:
+    raise ImportError(
+        "Не удалось загрузить ISelectionFilter из API Revit. Проверьте версию pyRevit/Revit."
+    )
+
 __title__ = "Разделить стену по слоям"
 __author__ = "pw-team"
 
@@ -88,7 +103,7 @@ class LayerInfo(object):
 
 
 def _pick_wall():
-    class WallSelectionFilter(DB.ISelectionFilter):
+    class WallSelectionFilter(_RevitSelectionFilterBase):
         def AllowElement(self, element):
             return isinstance(element, DB.Wall)
 


### PR DESCRIPTION
## Summary
- add compatibility imports for ISelectionFilter so wall selection works across Revit versions
- reuse the resolved selection interface when creating the wall selection filter class

## Testing
- not run (manual testing required in Revit)


------
https://chatgpt.com/codex/tasks/task_e_68d243a7806c83239e006354137cac6c