### PR TITLE
Fix hosted elements filter

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/SplitLayers.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/SplitLayers.pushbutton/script.py
@@ -383,8 +383,7 @@ class WallLayerSeparator:
     def get_hosted_elements(self):
         """Получение всех вложенных элементов (окна, двери и т.д.)"""
 
-        # Используем фильтр для поиска элементов, привязанных к стене
-        filter = FamilyInstanceFilter(doc, self.original_wall.Id)
+        # Собираем кандидатов из всех экземпляров семейств в документе
         collector = FilteredElementCollector(doc)
 
         # Собираем все FamilyInstance элементы


### PR DESCRIPTION
## Summary
- remove creation of a FamilyInstanceFilter with the wall id to avoid invalid family symbol errors when collecting hosted elements

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d253119e6c8323875e4490d75148d9