### PR TITLE
Добавить окно выбора слоёв перед разбивкой стен

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/SplitLayers.pushbutton/LayerSelection.xaml
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/SplitLayers.pushbutton/LayerSelection.xaml
@@ -1,0 +1,92 @@
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Разделение стен по слоям"
+        Height="420"
+        Width="720"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterScreen"
+        Background="White">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Разделение стен по слоям"
+                   FontSize="20"
+                   FontWeight="Bold"
+                   Margin="0,0,0,10" />
+
+        <TextBlock Grid.Row="1"
+                   Text="Выберите слои стены для замены"
+                   Margin="0,0,0,12" />
+
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="230" />
+                <ColumnDefinition Width="14" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0"
+                    BorderThickness="1"
+                    BorderBrush="#D0D0D0"
+                    Padding="4">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel x:Name="LayersPanel" />
+                </ScrollViewer>
+            </Border>
+
+            <Grid Grid.Column="2">
+                <DataGrid x:Name="LayerGrid"
+                          AutoGenerateColumns="False"
+                          HeadersVisibility="Column"
+                          CanUserAddRows="False"
+                          CanUserDeleteRows="False"
+                          CanUserReorderColumns="False"
+                          CanUserResizeColumns="False"
+                          IsReadOnly="False"
+                          GridLinesVisibility="Horizontal"
+                          RowHeaderWidth="0"
+                          Margin="0">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Имя слоя"
+                                            Binding="{Binding MaterialName}"
+                                            Width="*"
+                                            IsReadOnly="True" />
+                        <DataGridTextColumn Header="Толщина"
+                                            Binding="{Binding ThicknessDisplay}"
+                                            Width="130"
+                                            IsReadOnly="True" />
+                        <DataGridTemplateColumn Header="Заменяемый тип"
+                                                Width="220">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBox Text="{Binding ReplacementName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             Margin="2,0,2,0" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </Grid>
+
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,12,0,0">
+            <Button x:Name="CancelButton"
+                    Content="Отмена"
+                    Width="90"
+                    Margin="0,0,12,0"
+                    Click="cancel_click" />
+            <Button x:Name="OkButton"
+                    Content="Готово"
+                    Width="110"
+                    Click="ok_click" />
+        </StackPanel>
+    </Grid>
+</Window>


### PR DESCRIPTION
## Summary
- добавить XAML-разметку окна для выбора слоёв и задания имён типов
- внедрить показ нового окна перед разбивкой стены и учесть пользовательские выборы в логике плагина
- расширить обработку переноса вложенных элементов и генерации имён типов стен

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2589f342c832392017b1b8c11473d