### PR TITLE
Handle missing StackedWallUtils import

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/SplitLayers.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/SplitLayers.pushbutton/script.py
@@ -20,6 +20,18 @@ from Autodesk.Revit.UI import *
 from Autodesk.Revit.UI.Selection import ObjectType, ISelectionFilter
 from Autodesk.Revit.DB.Structure import *
 
+# В разных версиях Revit класс StackedWallUtils может находиться в разных
+# пространствах имён или отсутствовать вовсе. Выполняем безопасный импорт,
+# чтобы использовать его, когда он доступен, и корректно обрабатывать случаи,
+# когда API не предоставляет данный класс.
+try:
+    from Autodesk.Revit.DB import StackedWallUtils
+except Exception:
+    try:
+        from Autodesk.Revit.DB.Structure import StackedWallUtils
+    except Exception:
+        StackedWallUtils = None
+
 # Импорт PyRevit
 from pyrevit import revit, DB, UI
 from pyrevit import forms
@@ -175,6 +187,12 @@ class WallLayerSeparator:
         """Попытка получить структуру слоёв из сегментов составной стены."""
 
         self.stacked_member_types = []
+
+        if StackedWallUtils is None:
+            output.print_md(
+                u"⚠️ Класс `StackedWallUtils` недоступен в текущей версии Revit API."
+            )
+            return
 
         try:
             member_ids = StackedWallUtils.GetMemberIds(self.original_wall)


### PR DESCRIPTION
## Summary
- add a defensive import for `StackedWallUtils` to support different API namespaces
- stop executing stacked wall logic when the API does not provide `StackedWallUtils`

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d27aab60d48323897eaa1d9a63d037