### PR TITLE
Fix wall breakup vector reversal helper

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
@@ -188,17 +188,21 @@ def _compute_normal(curve):
     return normal.Normalize()
 
 
-def _negate_vector(vector):
+def _reverse_vector(vector):
     if vector is None:
         return XYZ.Zero
     try:
-        negated = vector.Negate()
-        if negated:
-            return negated
+        reversed_vector = vector.Negate()
+        if reversed_vector is not None:
+            return reversed_vector
     except Exception:
         pass
+
     try:
-        return XYZ(-getattr(vector, 'X', 0.0), -getattr(vector, 'Y', 0.0), -getattr(vector, 'Z', 0.0))
+        x = -getattr(vector, 'X', 0.0)
+        y = -getattr(vector, 'Y', 0.0)
+        z = -getattr(vector, 'Z', 0.0)
+        return XYZ(x, y, z)
     except Exception:
         return XYZ.Zero
 
@@ -526,7 +530,7 @@ def _breakup_wall(wall):
         return
 
     orientation = _ensure_orientation_vector(context, context['curve'])
-    inward = _negate_vector(orientation)
+    inward = _reverse_vector(orientation)
     try:
         inward = inward.Normalize()
     except Exception:


### PR DESCRIPTION
## Summary
- replace the missing `_negate_vector` helper with a new `_reverse_vector` implementation
- update the wall breakup routine to use the new helper when calculating the inward translation vector

## Testing
- not run (logic-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5aa9acd7883238c90d92c5b0bdb29