### PR TITLE
Add compatibility alias for vector negation

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
@@ -207,6 +207,11 @@ def _reverse_vector(vector):
         return XYZ.Zero
 
 
+def _negate_vector(vector):
+    """Совместимость с ранними версиями скрипта."""
+    return _reverse_vector(vector)
+
+
 def _scale_vector(vector, scale):
     if vector is None:
         return XYZ.Zero


### PR DESCRIPTION
## Summary
- add a `_negate_vector` helper that reuses `_reverse_vector`
- keep backward compatibility with scripts that still reference `_negate_vector`

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5ae4bf9048323a25bebc752612dc0