### PR TITLE
Fix material fallback when splitting wall layers

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
@@ -158,9 +158,31 @@ def _structure_layers_data(structure):
                 candidate = getattr(layer, attr)
             except Exception:
                 candidate = None
-            if candidate and isinstance(candidate, ElementId) and candidate.IntegerValue > 0:
+
+            if (
+                candidate
+                and isinstance(candidate, ElementId)
+                and candidate.IntegerValue > 0
+            ):
                 material_id = candidate
                 break
+
+        if (
+            (material_id is None)
+            or (not isinstance(material_id, ElementId))
+            or material_id.IntegerValue < 1
+        ):
+            try:
+                candidate = structure.GetMaterialId(idx)
+            except Exception:
+                candidate = None
+
+            if (
+                candidate
+                and isinstance(candidate, ElementId)
+                and candidate.IntegerValue > 0
+            ):
+                material_id = candidate
 
         try:
             function = layer.Function


### PR DESCRIPTION
## Summary
- ensure each layer fallback retrieves its material from the compound structure when direct layer properties are empty

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d634aef5708323ad84012e6cae1652