### PR TITLE
Ensure rehosted openings cut all wall layers

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
@@ -636,6 +636,8 @@ def _rehost_instances(instances, new_host_wall, other_walls=None):
     if other_walls is None:
         other_walls = []
 
+    created_instances = []
+
     for info in instances:
         symbol = info['symbol']
         if symbol is None:
@@ -680,15 +682,28 @@ def _rehost_instances(instances, new_host_wall, other_walls=None):
         except Exception:
             pass
 
-        if _CAN_ADD_VOID_CUT and _ADD_INSTANCE_VOID_CUT:
-            for extra_wall in other_walls:
-                if extra_wall is None or extra_wall.Id == new_host_wall.Id:
-                    continue
-                try:
-                    if _CAN_ADD_VOID_CUT(doc, new_inst, extra_wall):
-                        _ADD_INSTANCE_VOID_CUT(doc, new_inst, extra_wall)
-                except Exception:
-                    continue
+        created_instances.append(new_inst)
+
+    if not created_instances:
+        return
+
+    try:
+        doc.Regenerate()
+    except Exception:
+        pass
+
+    if not (_CAN_ADD_VOID_CUT and _ADD_INSTANCE_VOID_CUT):
+        return
+
+    for new_inst in created_instances:
+        for extra_wall in other_walls:
+            if extra_wall is None or extra_wall.Id == new_host_wall.Id:
+                continue
+            try:
+                if _CAN_ADD_VOID_CUT(doc, new_inst, extra_wall):
+                    _ADD_INSTANCE_VOID_CUT(doc, new_inst, extra_wall)
+            except Exception:
+                continue
 
 
 def _breakup_wall(wall):


### PR DESCRIPTION
## Summary
- regenerate the document after recreating hosted instances and track them for follow-up processing
- ensure rehosted doors/windows attempt to add void cuts against every newly created wall layer

## Testing
- not run (Revit API environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6a3f3c6e08323b80fd552cf1a55b6