### PR TITLE
Fix WallJoinType import for older Revit versions

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
@@ -46,7 +46,6 @@ from Autodesk.Revit.DB import (
     Options,
     Solid,
     ViewDetailLevel,
-    WallJoinType,
 )
 from Autodesk.Revit.DB.Structure import StructuralType
 from Autodesk.Revit.UI.Selection import ObjectType
@@ -71,7 +70,12 @@ _ADD_INSTANCE_VOID_CUT = getattr(InstanceVoidCutUtils, 'AddInstanceVoidCut', Non
 _APPLY_WALL_JOIN_TYPE = getattr(WallUtils, 'ApplyJoinType', None)
 
 try:
-    _WALL_JOIN_TYPE_BUTT = WallJoinType.Butt
+    from Autodesk.Revit.DB import WallJoinType  # type: ignore
+except Exception:
+    WallJoinType = None
+
+try:
+    _WALL_JOIN_TYPE_BUTT = WallJoinType.Butt if WallJoinType is not None else None
 except Exception:
     _WALL_JOIN_TYPE_BUTT = None
 


### PR DESCRIPTION
## Summary
- guard the optional WallJoinType import so the script works on Revit builds without it
- keep wall join application conditional when the enum is unavailable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da364bd0f48323919d7591524af0b6