### PR TITLE
Add Excel template filling helper

### DIFF
--- a/section3_parser.py
+++ b/section3_parser.py
@@ -329,9 +329,31 @@ def _build_lookup() -> Dict[str, str]:
 HEADER_LOOKUP = _build_lookup()
 
 
+def identify_section3_field(header: object) -> Optional[str]:
+    """Возвращает имя поля раздела 3, соответствующее заголовку.
+
+    Функция принимает исходный заголовок таблицы и пытается определить,
+    какое поле раздела 3 он описывает.  Если сопоставление выполнить не
+    удалось, возвращается ``None``.  Логика полностью повторяет ту, что
+    используется внутри :func:`extract_section3_rows`.
+    """
+
+    normalized = _normalize_header(header)
+    if not normalized:
+        return None
+
+    match = _match_field(normalized)
+    if match is None:
+        return None
+
+    field, _priority = match
+    return field
+
+
 __all__ = [
     "SECTION3_FIELDS",
     "NUMERIC_FIELDS",
     "extract_section3_rows",
+    "identify_section3_field",
 ]
 

--- a/section3_template.py
+++ b/section3_template.py
@@ -1,0 +1,236 @@
+"""Утилиты для заполнения шаблона раздела 3 в формате Excel."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from functools import lru_cache
+from typing import Callable, Iterable, Mapping, MutableMapping, Optional, Sequence, TYPE_CHECKING
+
+from section3_parser import SECTION3_FIELDS, identify_section3_field
+
+if TYPE_CHECKING:  # pragma: no cover - используется только для типов
+    from openpyxl.worksheet.worksheet import Worksheet
+
+_STOP_KEYWORDS = ("итого", "раздел", "примечан")
+
+
+def fill_section3_template(
+    template_path: str,
+    rows: Iterable[Mapping[str, object] | object],
+    *,
+    output_path: Optional[str] = None,
+    sheet_name: Optional[str] = None,
+    data_start_cell: Optional[str] = None,
+    numbering_column: Optional[str | int] = None,
+) -> str:
+    """Заполняет таблицу раздела 3 в Excel-шаблоне.
+
+    Parameters
+    ----------
+    template_path:
+        Путь до исходного шаблона Excel (``.xlsx``).  Стиль и форматирование
+        берутся именно из этого файла.
+    rows:
+        Последовательность записей раздела 3.  Как правило, это результат
+        :func:`section3_parser.extract_section3_rows`.  Допускаются словари,
+        объекты с методом ``dict`` или датаклассы — данные будут приведены
+        к словарю автоматически.
+    output_path:
+        Если указан, заполненный файл сохраняется по этому пути.  В
+        противном случае исходный ``template_path`` будет перезаписан.
+    sheet_name:
+        Имя листа, на котором находится таблица.  Если не задано, будет
+        использован активный лист книги.
+    data_start_cell:
+        Ячейка, с которой начинается первая строка таблицы.  Если параметр
+        опущен, функция попытается автоматически найти строку с заголовками
+        и определить расположение колонок.
+    numbering_column:
+        Буквенный адрес или индекс колонки с порядковым номером строк.
+        При ``None`` попытка определить колонку производится автоматически
+        (по заголовку, содержащему символ ``№``).
+
+    Returns
+    -------
+    str
+        Путь к сохранённому файлу (``output_path`` или ``template_path``).
+    """
+
+    load_workbook, column_index_from_string, coordinate_from_string = _require_openpyxl()
+
+    workbook = load_workbook(template_path)
+    worksheet = workbook[sheet_name] if sheet_name else workbook.active
+
+    normalized_rows = [_coerce_row(row) for row in rows]
+
+    header_row, column_map = _resolve_layout(
+        worksheet, data_start_cell, column_index_from_string, coordinate_from_string
+    )
+    data_row_index = (
+        coordinate_from_string(data_start_cell)[1]
+        if data_start_cell
+        else header_row + 1
+    )
+
+    numbering_index = _resolve_numbering_column(
+        worksheet, numbering_column, header_row, column_map, column_index_from_string
+    )
+
+    existing_rows = _count_existing_rows(worksheet, column_map, data_row_index)
+    rows_to_clear = max(existing_rows, len(normalized_rows))
+    if not rows_to_clear:
+        rows_to_clear = 1
+
+    _clear_rows(worksheet, column_map, data_row_index, rows_to_clear, numbering_index)
+
+    for offset, row in enumerate(normalized_rows):
+        current_row = data_row_index + offset
+        if numbering_index is not None:
+            worksheet.cell(row=current_row, column=numbering_index).value = offset + 1
+        for field, column_index in column_map.items():
+            worksheet.cell(row=current_row, column=column_index).value = row.get(field)
+
+    destination = output_path or template_path
+    workbook.save(destination)
+    return destination
+
+
+def _coerce_row(row: Mapping[str, object] | object) -> MutableMapping[str, object]:
+    if isinstance(row, Mapping):
+        return {str(key): value for key, value in row.items()}
+
+    if is_dataclass(row):
+        return dict(asdict(row))
+
+    to_dict = getattr(row, "to_dict", None)
+    if callable(to_dict):
+        result = to_dict()
+        if isinstance(result, Mapping):
+            return {str(key): value for key, value in result.items()}
+
+    raise TypeError("row must be mapping-like or convertible to dict")
+
+
+def _resolve_layout(
+    worksheet: "Worksheet",
+    data_start_cell: Optional[str],
+    column_index_from_string: Callable[[str], int],
+    coordinate_from_string: Callable[[str], tuple[str, int]],
+) -> tuple[int, dict[str, int]]:
+    if data_start_cell:
+        column_letter, row_index = coordinate_from_string(data_start_cell)
+        start_column = column_index_from_string(column_letter)
+        column_map = {
+            field: start_column + offset for offset, field in enumerate(SECTION3_FIELDS)
+        }
+        return row_index - 1, column_map
+
+    for row in worksheet.iter_rows():
+        header_row_index = row[0].row
+        mapping: dict[str, int] = {}
+        for cell in row:
+            field = identify_section3_field(cell.value)
+            if field and field not in mapping:
+                mapping[field] = cell.col_idx
+        if len(mapping) == len(SECTION3_FIELDS):
+            return header_row_index, mapping
+
+    raise ValueError("Не удалось найти строку с заголовками раздела 3")
+
+
+def _resolve_numbering_column(
+    worksheet: "Worksheet",
+    numbering_column: Optional[str | int],
+    header_row: int,
+    column_map: Mapping[str, int],
+    column_index_from_string: Callable[[str], int],
+) -> Optional[int]:
+    if numbering_column is None:
+        left_column = min(column_map.values()) - 1
+        if left_column >= 1:
+            header_value = worksheet.cell(row=header_row, column=left_column).value
+            if isinstance(header_value, str) and "№" in header_value:
+                return left_column
+        return None
+
+    if isinstance(numbering_column, int):
+        if numbering_column < 1:
+            raise ValueError("numbering_column must be positive")
+        return numbering_column
+
+    column = numbering_column.strip()
+    if not column:
+        return None
+    return column_index_from_string(column)
+
+
+def _count_existing_rows(
+    worksheet: "Worksheet",
+    column_map: Mapping[str, int],
+    start_row: int,
+) -> int:
+    max_row = worksheet.max_row
+    row_index = start_row
+    count = 0
+    while row_index <= max_row:
+        values = [worksheet.cell(row=row_index, column=col).value for col in column_map.values()]
+        if _is_footer_row(values):
+            break
+        if all(_is_empty(value) for value in values):
+            break
+        count += 1
+        row_index += 1
+    return count
+
+
+def _clear_rows(
+    worksheet: "Worksheet",
+    column_map: Mapping[str, int],
+    start_row: int,
+    count: int,
+    numbering_column: Optional[int],
+) -> None:
+    for offset in range(count):
+        row_index = start_row + offset
+        for column_index in column_map.values():
+            worksheet.cell(row=row_index, column=column_index).value = None
+        if numbering_column is not None:
+            worksheet.cell(row=row_index, column=numbering_column).value = None
+
+
+def _is_empty(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
+def _is_footer_row(values: Sequence[object]) -> bool:
+    for value in values:
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if any(keyword in normalized for keyword in _STOP_KEYWORDS):
+                return True
+    return False
+
+
+__all__ = ["fill_section3_template"]
+
+
+@lru_cache(maxsize=1)
+def _require_openpyxl():
+    try:
+        from openpyxl import load_workbook  # type: ignore import
+        from openpyxl.utils.cell import (  # type: ignore import
+            column_index_from_string,
+            coordinate_from_string,
+        )
+    except ModuleNotFoundError as exc:  # pragma: no cover - зависит от окружения
+        raise ModuleNotFoundError(
+            "Для заполнения шаблона необходим пакет openpyxl. "
+            "Установите его командой 'pip install openpyxl'."
+        ) from exc
+
+    return load_workbook, column_index_from_string, coordinate_from_string
+

--- a/tests/test_section3_template.py
+++ b/tests/test_section3_template.py
@@ -1,0 +1,165 @@
+import os
+import tempfile
+import unittest
+
+try:
+    from openpyxl import Workbook, load_workbook
+except ModuleNotFoundError:  # pragma: no cover - зависит от окружения
+    Workbook = load_workbook = None  # type: ignore[assignment]
+
+from section3_template import fill_section3_template
+
+
+@unittest.skipIf(Workbook is None, "openpyxl не установлен")
+class Section3TemplateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+    def _create_template(self, filename: str = "template.xlsx") -> str:
+        path = os.path.join(self.temp_dir.name, filename)
+        workbook = Workbook()
+        sheet = workbook.active
+        sheet.title = "Справка"
+
+        headers = (
+            "№",
+            "Условный номер помещения",
+            "Назначение помещения",
+            "Этаж расположения",
+            "Номер подъезда",
+            "Площадь, м2",
+            "Наименование помещения",
+            "Площадь части, м2",
+            "Высота потолков, м",
+        )
+        for column, value in enumerate(headers, start=2):
+            sheet.cell(row=8, column=column).value = value
+
+        # Добавим строку итога ниже предполагаемой таблицы, чтобы убедиться,
+        # что функция не затронет её.
+        sheet.cell(row=20, column=3).value = "Итого"
+        sheet.cell(row=20, column=6).value = "=SUM(F9:F19)"
+
+        workbook.save(path)
+        return path
+
+    def test_fill_template_writes_rows_and_numbers(self):
+        template_path = self._create_template()
+        output_path = os.path.join(self.temp_dir.name, "result.xlsx")
+
+        rows = [
+            {
+                "unit_number": "НП-1",
+                "purpose": "Магазин",
+                "floor": "1",
+                "entrance_number": "2",
+                "area": 35.7,
+                "room_name": "Помещение 101",
+                "part_area": 35.7,
+                "ceiling_height": 3.45,
+            },
+            {
+                "unit_number": "НП-2",
+                "purpose": "Кафе",
+                "floor": "1",
+                "entrance_number": "1",
+                "area": 42.1,
+                "room_name": "Помещение 102",
+                "part_area": 41.3,
+                "ceiling_height": 3.6,
+            },
+        ]
+
+        fill_section3_template(template_path, rows, output_path=output_path)
+
+        workbook = load_workbook(output_path, data_only=True)
+        sheet = workbook.active
+
+        self.assertEqual(sheet["B9"].value, 1)
+        self.assertEqual(sheet["B10"].value, 2)
+        self.assertEqual(sheet["C9"].value, "НП-1")
+        self.assertEqual(sheet["D10"].value, "Кафе")
+        self.assertEqual(sheet["G9"].value, 35.7)
+        self.assertEqual(sheet["I10"].value, 41.3)
+        # Строка "Итого" должна сохраниться.
+        self.assertEqual(sheet["C20"].value, "Итого")
+
+    def test_fill_template_clears_previous_rows(self):
+        template_path = self._create_template()
+
+        workbook = load_workbook(template_path)
+        sheet = workbook.active
+        sheet["B9"].value = 1
+        sheet["C9"].value = "Старые данные"
+        sheet["B10"].value = 2
+        sheet["C10"].value = "Будет очищено"
+        workbook.save(template_path)
+
+        rows = [
+            {
+                "unit_number": "НП-3",
+                "purpose": "Офис",
+                "floor": "2",
+                "entrance_number": "1",
+                "area": 18.5,
+                "room_name": "Помещение 201",
+                "part_area": 18.5,
+                "ceiling_height": 3.2,
+            }
+        ]
+
+        fill_section3_template(template_path, rows)
+
+        workbook = load_workbook(template_path)
+        sheet = workbook.active
+
+        self.assertIsNone(sheet["B10"].value)
+        self.assertIsNone(sheet["C10"].value)
+        self.assertEqual(sheet["C9"].value, "НП-3")
+
+    def test_fill_template_with_explicit_start_cell(self):
+        template_path = self._create_template()
+        workbook = load_workbook(template_path)
+        sheet = workbook.active
+        sheet["J5"].value = "Условный номер помещения"
+        sheet["K5"].value = "Назначение помещения"
+        sheet["L5"].value = "Этаж расположения"
+        sheet["M5"].value = "Номер подъезда"
+        sheet["N5"].value = "Площадь, м2"
+        sheet["O5"].value = "Наименование помещения"
+        sheet["P5"].value = "Площадь части, м2"
+        sheet["Q5"].value = "Высота потолков, м"
+        workbook.save(template_path)
+
+        rows = [
+            {
+                "unit_number": "НП-4",
+                "purpose": "Фитнес",
+                "floor": "1",
+                "entrance_number": "3",
+                "area": 55.0,
+                "room_name": "Помещение 301",
+                "part_area": 55.0,
+                "ceiling_height": 4.1,
+            }
+        ]
+
+        fill_section3_template(
+            template_path,
+            rows,
+            data_start_cell="J6",
+            numbering_column="I",
+        )
+
+        workbook = load_workbook(template_path)
+        sheet = workbook.active
+
+        self.assertEqual(sheet["I6"].value, 1)
+        self.assertEqual(sheet["J6"].value, "НП-4")
+        self.assertEqual(sheet["Q6"].value, 4.1)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- expose a public helper to match section 3 headers to fields
- add a utility that fills an XLSX section 3 template while preserving formatting
- cover the exporter with unit tests, including custom start cell handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db77297b308323bb881f9c3be7fbce