### PR TITLE
Fix encoding header position for pyRevit script

### DIFF
--- a/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
+++ b/SplitLayers.extension/LayerTools.tab/LayerTools.panel/MockBreakupWalls.pushbutton/script.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 # -*- coding: utf-8 -*-
+
+from __future__ import annotations
 """Разбивает составную стену на отдельные стены-слои, автоматически создавая тип для каждого слоя."""
 
 import sys


### PR DESCRIPTION
## Summary
- move the UTF-8 encoding declaration to the first line of the MockBreakupWalls script so IronPython can read Cyrillic text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de4507a5c08323bbf19fa0ab67a6fa