### PR TITLE
Fix section3 parser compatibility with older Python runtimes

### DIFF
--- a/section3_parser.py
+++ b/section3_parser.py
@@ -10,11 +10,9 @@
 в формате, удобном для последующей выгрузки в шаблон раздела 3.
 """
 
-from __future__ import annotations
-
 import math
 import re
-from typing import Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Sequence
+from typing import Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 # Порядок полей соответствует структуре раздела 3.
 SECTION3_FIELDS: Sequence[str] = (
@@ -192,7 +190,7 @@ def _normalize_header(value: object) -> str:
     return text.strip()
 
 
-def _match_field(normalized_header: str) -> Optional[tuple[str, int]]:
+def _match_field(normalized_header: str) -> Optional[Tuple[str, int]]:
     """Определяет, к какому полю относится заголовок."""
 
     if not normalized_header:
@@ -202,7 +200,7 @@ def _match_field(normalized_header: str) -> Optional[tuple[str, int]]:
     if lookup:
         return lookup, 0
 
-    checks: List[tuple[str, int]] = []
+    checks: List[Tuple[str, int]] = []
 
     if "условн" in normalized_header and "номер" in normalized_header:
         checks.append(("unit_number", 1))


### PR DESCRIPTION
## Summary
- remove the `__future__` annotations import that IronPython does not recognize
- switch to classic typing generics so the module still type-checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de461e81448323906aaf687430208e